### PR TITLE
Refactor state hydration and snapshot equality assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/yaml": "^1.9.7",
     "chai": "^4.3.4",
     "crypto-js": "^4.0.0",
-    "fast-deep-equal": "^3.1.3",
     "mocha": "^8.3.2",
     "sinon": "^10.0.0",
     "sparkles": "^1.0.1",

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -1,9 +1,18 @@
-export default class Entity {
-    public id: string;
-    public params: any;
+import sha256 from "crypto-js/sha256";
 
-    constructor(id: string, params?: any) {
-        this.id = id;
-        this.params = params || {};
-    }
+export default class Entity {
+  public id: string;
+  public params: any;
+
+  constructor(id: string, params?: any) {
+    this.id = id;
+    this.params = params || {};
+  }
+
+  public equals = (e: Entity) => {
+    return (
+      sha256(JSON.stringify(e)).toString() ===
+      sha256(JSON.stringify(this)).toString()
+    );
+  }
 }

--- a/src/classes/Store.ts
+++ b/src/classes/Store.ts
@@ -42,6 +42,21 @@ export default class Store {
 
   public addEntity = (entityKey: string, entity: Entity): void => {
     assert(entityKey.trim() !== "", "Entity key cannot be an empty string.");
+    assert(
+      this.state.get(entityKey) === undefined,
+      `Entity with key ${entityKey} already exists in the state. If you want to update it, use state.updateEntity().`,
+    );
+
+    this.state.set(entityKey, entity);
+  }
+
+  public updateEntity = (entityKey: string, entity: Entity): void => {
+    assert(entityKey.trim() !== "", "Entity key cannot be an empty string.");
+    assert(
+      this.state.get(entityKey) !== undefined,
+      `Entity key ${entityKey} not found in state. Try adding the entity first with store.addEntity().`,
+    );
+
     this.state.set(entityKey, entity);
   }
 

--- a/src/classes/Store.ts
+++ b/src/classes/Store.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import equal from "fast-deep-equal/es6";
+import sha256 from "crypto-js/sha256";
 import Entity from "./Entity";
 
 // tslint:disable-next-line: no-var-requires
@@ -76,9 +76,10 @@ export default class Store {
       "Cannot check for equality when the state is empty. You need to first hydrate the state.",
     );
 
-    const snapshotMap: Map<string, Entity> = new Map(JSON.parse(snapshot));
+    const snapshotHash = sha256(snapshot).toString();
+    const stateHash = sha256(this.readStateJson()).toString();
     assert(
-      equal(snapshotMap, this.state),
+      snapshotHash === stateHash,
       "Provided snapshot map is not equal to the store.",
     );
   }

--- a/src/classes/Store.ts
+++ b/src/classes/Store.ts
@@ -92,7 +92,7 @@ export default class Store {
     );
 
     assert(
-      equal(this.state.get(entityKey), entity),
+      entity.equals(this.state.get(entityKey)!),
       "Provided entity is not equal to corresponding entity with given entity key in the state.",
     );
   }
@@ -103,7 +103,7 @@ export default class Store {
 
     return (
       entitiesList.findIndex((e) => {
-        return equal(e, entity);
+        return e.equals(entity);
       }) > -1
     );
   }

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -16,7 +16,6 @@ describe("Store", () => {
 
   beforeEach(() => {
     store = new Store();
-
     entities.set("dragonEntityKey", dragonEntity);
     entities.set("coinEntityKey", coinEntity);
     entities.delete("rabbitEntityKey");

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -39,7 +39,7 @@ describe("Store", () => {
     const endStateMap = store.readStateMap();
     expect(endStateMap).length(3);
     expect(JSON.stringify(Array.from(endStateMap.entries()))).equals(
-      JSON.stringify(fantasyEntities)
+      JSON.stringify(fantasyEntities),
     );
   });
 
@@ -64,13 +64,13 @@ describe("Store", () => {
     expect(() => {
       store.hydrateWithJson(JSON.stringify(sciFiEntities));
     }).throws(
-      `State is not empty. Please use state.clear() to clear the state before hydrating.`
+      `State is not empty. Please use state.clear() to clear the state before hydrating.`,
     );
 
     expect(() => {
       store.hydrateWithEntities(entities);
     }).throws(
-      `State is not empty. Please use state.clear() to clear the state before hydrating.`
+      `State is not empty. Please use state.clear() to clear the state before hydrating.`,
     );
   });
 
@@ -84,7 +84,7 @@ describe("Store", () => {
     expect(() => {
       store.assertStateSnapshotEq(JSON.stringify(fantasyEntities));
     }).throws(
-      `Cannot check for equality when the state is empty. You need to first hydrate the state.`
+      `Cannot check for equality when the state is empty. You need to first hydrate the state.`,
     );
   });
 
@@ -121,7 +121,7 @@ describe("Store", () => {
     expect(() => {
       store.assertEntityEq("dragonEntityKey", coinEntity);
     }).throws(
-      `Provided entity is not equal to corresponding entity with given entity key in the state.`
+      `Provided entity is not equal to corresponding entity with given entity key in the state.`,
     );
   });
 
@@ -202,5 +202,45 @@ describe("Store", () => {
     expect(dragonEntityKeyExists).equals(false);
     expect(dragonEntityExists).equals(false);
     expect(store.size()).equals(1);
+  });
+
+  it("Fails to add an entity if the given key already exists in the state", () => {
+    store.hydrateWithEntities(entities);
+    const anotherDragonEntity = new Entity("688", "The dragon is purple");
+
+    expect(() => {
+      store.addEntity("dragonEntityKey", anotherDragonEntity);
+    }).throws(
+      // tslint:disable-next-line: max-line-length
+      `Entity with key dragonEntityKey already exists in the state. If you want to update it, use state.updateEntity().`,
+    );
+  });
+
+  it("Updates entity correctly", () => {
+    store.hydrateWithEntities(entities);
+    const updatedDragonEntity = new Entity("688", "The dragon is purple");
+
+    store.updateEntity("dragonEntityKey", updatedDragonEntity);
+    expect(store.entityExists(updatedDragonEntity)).equals(true);
+  });
+
+  it("Fails when trying to update entity with an empty key", () => {
+    store.hydrateWithEntities(entities);
+    const updatedDragonEntity = new Entity("688", "The dragon is purple");
+
+    expect(() => {
+      store.updateEntity("  ", updatedDragonEntity);
+    }).throws(`Entity key cannot be an empty string.`);
+  });
+
+  it("Fails when trying to update an entity that does not yet exist in the state", () => {
+    store.hydrateWithEntities(entities);
+    const updatedDragonEntity = new Entity("688", "The dragon is purple");
+
+    expect(() => {
+      store.updateEntity("purpleDragonEntityKey", updatedDragonEntity);
+    }).throws(
+      `Entity key purpleDragonEntityKey not found in state. Try adding the entity first with store.addEntity().`,
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,7 +1344,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
This PR addresses comments made on https://github.com/LimeChain/subgraph-tester/pull/3 That includes:
1. Create separate methods for adding and updating an entity in the store.
2. Add assertions e.g. throw an error when the user is attempting to add an entity with a key that already exists in the store. And the other way around - throw an error if the user tries to update an entity, providing a key that does not yet exist in the store.
3. Remove the `fast-deep-equal` package and instead compare the hash of the provided JSON to the hash of the JSON stringified map, when asserting for equality.